### PR TITLE
Speed up cloning and printf format with inttypes.h

### DIFF
--- a/FreeRTOS_IP.c.patch
+++ b/FreeRTOS_IP.c.patch
@@ -2,12 +2,22 @@ diff --git a/FreeRTOS-Plus-TCP/FreeRTOS_IP.c b/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
 index bfd2a9c..112e879 100644
 --- a/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
 +++ b/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
+@@ -27,6 +27,7 @@
+ #include <stdint.h>
+ #include <stdio.h>
+ #include <string.h>
++#include <inttypes.h>
+
+ /* FreeRTOS includes. */
+ #include "FreeRTOS.h"
+--- a/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
++++ b/FreeRTOS-Plus-TCP/FreeRTOS_IP.c
 @@ -2818,7 +2818,7 @@ const char *pcName;
  		case pdFREERTOS_ERRNO_EISCONN:        pcName = "EISCONN"; break;
  		default:
  			/* Using function "snprintf". */
 -			( void ) snprintf( pcBuffer, uxLength, "Errno %d", ( int32_t ) xErrnum );
-+			( void ) snprintf( pcBuffer, uxLength, "Errno %ld", ( int32_t ) xErrnum );
++			( void ) snprintf( pcBuffer, uxLength, "Errno %" PRId32, ( int32_t ) xErrnum );
  			pcName = NULL;
  			break;
  	}

--- a/update.py
+++ b/update.py
@@ -30,7 +30,7 @@ source_paths_tcp = [
 # clone the repository
 print("Cloning FreeRTOS repository...")
 if not Path("freertos_src").exists():
-    subprocess.run("git clone --recurse-submodules https://github.com/freertos/freertos.git freertos_src", shell=True)
+    subprocess.run("git clone --jobs=8 --recurse-submodules https://github.com/freertos/freertos.git freertos_src", shell=True)
 
 # remove the sources in this repo
 if Path("FreeRTOS").exists():


### PR DESCRIPTION
Use `PRIxN` for all width-based integral types for best cross-plattform compatibility. Maybe fix upstream.